### PR TITLE
Implement responsive scratch zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# scratchtoreveal
+# Scratch To Reveal
+
+Simple scratchcard demo.

--- a/index.html
+++ b/index.html
@@ -27,98 +27,123 @@
       display: block;
     }
 
-    #scratchCanvas {
+    .scratch-zone {
+      position: absolute;
+      width: 24.17%;
+      height: 13.41%;
+    }
+
+    .scratch-zone img {
+      display: block;
+      width: 100%;
+      height: 100%;
+    }
+
+    .scratch-zone canvas {
       position: absolute;
       top: 0;
       left: 0;
       width: 100%;
       height: 100%;
       touch-action: none;
-      background: transparent;
-    }
-
-    .circle {
-      position: absolute;
-      width: 24.17%;
-      height: 13.41%;
     }
   </style>
 </head>
 <body>
   <div id="container">
     <img id="ticket" src="background.png" alt="Gender reveal ticket" />
-    <img class="circle" src="circle.png" style="left: 7.00%; top: 65.58%;" />
-    <img class="circle" src="circle.png" style="left: 37.92%; top: 65.58%;" />
-    <img class="circle" src="circle.png" style="left: 68.84%; top: 65.58%;" />
-    <img class="circle" src="circle.png" style="left: 21.61%; top: 80.94%;" />
-    <img class="circle" src="circle.png" style="left: 54.19%; top: 80.38%;" />
-    <canvas id="scratchCanvas"></canvas>
+    <div class="scratch-zone" style="left: 7.00%; top: 65.58%;">
+      <img src='data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%20100%20100%27%3E%3Crect%20width%3D%27100%25%27%20height%3D%27100%25%27%20fill%3D%27%23f88%27/%3E%3Ctext%20x%3D%2750%25%27%20y%3D%2755%27%20font-size%3D%2750%27%20text-anchor%3D%27middle%27%20fill%3D%27%23fff%27%3E1%3C/text%3E%3C/svg%3E' alt="Reveal 1" />
+      <canvas></canvas>
+    </div>
+    <div class="scratch-zone" style="left: 37.92%; top: 65.58%;">
+      <img src='data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%20100%20100%27%3E%3Crect%20width%3D%27100%25%27%20height%3D%27100%25%27%20fill%3D%27%238f8%27/%3E%3Ctext%20x%3D%2750%25%27%20y%3D%2755%27%20font-size%3D%2750%27%20text-anchor%3D%27middle%27%20fill%3D%27%23fff%27%3E2%3C/text%3E%3C/svg%3E' alt="Reveal 2" />
+      <canvas></canvas>
+    </div>
+    <div class="scratch-zone" style="left: 68.84%; top: 65.58%;">
+      <img src='data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%20100%20100%27%3E%3Crect%20width%3D%27100%25%27%20height%3D%27100%25%27%20fill%3D%27%2388f%27/%3E%3Ctext%20x%3D%2750%25%27%20y%3D%2755%27%20font-size%3D%2750%27%20text-anchor%3D%27middle%27%20fill%3D%27%23fff%27%3E3%3C/text%3E%3C/svg%3E' alt="Reveal 3" />
+      <canvas></canvas>
+    </div>
+    <div class="scratch-zone" style="left: 21.61%; top: 80.94%;">
+      <img src='data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%20100%20100%27%3E%3Crect%20width%3D%27100%25%27%20height%3D%27100%25%27%20fill%3D%27%23ff8%27/%3E%3Ctext%20x%3D%2750%25%27%20y%3D%2755%27%20font-size%3D%2750%27%20text-anchor%3D%27middle%27%20fill%3D%27%23fff%27%3E4%3C/text%3E%3C/svg%3E' alt="Reveal 4" />
+      <canvas></canvas>
+    </div>
+    <div class="scratch-zone" style="left: 54.19%; top: 80.38%;">
+      <img src='data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%20100%20100%27%3E%3Crect%20width%3D%27100%25%27%20height%3D%27100%25%27%20fill%3D%27%238ff%27/%3E%3Ctext%20x%3D%2750%25%27%20y%3D%2755%27%20font-size%3D%2750%27%20text-anchor%3D%27middle%27%20fill%3D%27%23fff%27%3E5%3C/text%3E%3C/svg%3E' alt="Reveal 5" />
+      <canvas></canvas>
+    </div>
   </div>
 
   <script>
-    const canvas = document.getElementById('scratchCanvas');
-    const ctx = canvas.getContext('2d');
-    const ticket = document.getElementById('ticket');
     const radius = 20;
-    let isDrawing = false;
+    const overlaySrc = 'circle.png';
 
-    function resizeCanvasToMatchImage() {
-      const rect = ticket.getBoundingClientRect();
-      canvas.width = rect.width;
-      canvas.height = rect.height;
+    function setupZone(zone) {
+      const canvas = zone.querySelector('canvas');
+      const ctx = canvas.getContext('2d');
+      const overlay = new Image();
+      overlay.src = overlaySrc;
 
-      // No overlay filled here — leaving the canvas transparent
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      function redraw() {
+        canvas.width = zone.clientWidth;
+        canvas.height = zone.clientHeight;
+        ctx.globalCompositeOperation = 'source-over';
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.drawImage(overlay, 0, 0, canvas.width, canvas.height);
+      }
+
+      overlay.onload = redraw;
+      window.addEventListener('resize', redraw);
+
+      let drawing = false;
+
+      function getPos(e) {
+        const rect = canvas.getBoundingClientRect();
+        const x = (e.clientX || e.touches[0].clientX) - rect.left;
+        const y = (e.clientY || e.touches[0].clientY) - rect.top;
+        return { x, y };
+      }
+
+      function scratch(x, y) {
+        ctx.globalCompositeOperation = 'destination-out';
+        ctx.beginPath();
+        ctx.arc(x, y, radius, 0, Math.PI * 2);
+        ctx.fill();
+      }
+
+      canvas.addEventListener('mousedown', e => {
+        drawing = true;
+        const { x, y } = getPos(e);
+        scratch(x, y);
+      });
+
+      canvas.addEventListener('mousemove', e => {
+        if (!drawing) return;
+        const { x, y } = getPos(e);
+        scratch(x, y);
+      });
+
+      document.addEventListener('mouseup', () => drawing = false);
+
+      canvas.addEventListener('touchstart', e => {
+        drawing = true;
+        const { x, y } = getPos(e);
+        scratch(x, y);
+      });
+
+      canvas.addEventListener('touchmove', e => {
+        if (!drawing) return;
+        e.preventDefault();
+        const { x, y } = getPos(e);
+        scratch(x, y);
+      });
+
+      document.addEventListener('touchend', () => drawing = false);
     }
 
-    function getPos(e) {
-      const rect = canvas.getBoundingClientRect();
-      const x = (e.clientX || e.touches[0].clientX) - rect.left;
-      const y = (e.clientY || e.touches[0].clientY) - rect.top;
-      return { x, y };
-    }
-
-    function scratch(x, y) {
-      ctx.globalCompositeOperation = 'destination-out';
-      ctx.beginPath();
-      ctx.arc(x, y, radius, 0, Math.PI * 2);
-      ctx.fill();
-    }
-
-    // Mouse events
-    canvas.addEventListener('mousedown', (e) => {
-      isDrawing = true;
-      const { x, y } = getPos(e);
-      scratch(x, y);
+    window.addEventListener('load', () => {
+      document.querySelectorAll('.scratch-zone').forEach(setupZone);
     });
-
-    canvas.addEventListener('mousemove', (e) => {
-      if (!isDrawing) return;
-      const { x, y } = getPos(e);
-      scratch(x, y);
-    });
-
-    document.addEventListener('mouseup', () => isDrawing = false);
-
-    // Touch events
-    canvas.addEventListener('touchstart', (e) => {
-      isDrawing = true;
-      const { x, y } = getPos(e);
-      scratch(x, y);
-    });
-
-    canvas.addEventListener('touchmove', (e) => {
-      if (!isDrawing) return;
-      e.preventDefault(); // Prevent scrolling
-      const { x, y } = getPos(e);
-      scratch(x, y);
-    });
-
-    document.addEventListener('touchend', () => isDrawing = false);
-
-    // Initialize
-    window.addEventListener('load', resizeCanvasToMatchImage);
-    window.addEventListener('resize', resizeCanvasToMatchImage);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement per-scratch-zone canvas with responsive sizing
- show placeholder reveal images using inline SVG
- clean up the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687c78571538832fb1badf69eb2d4b50