### PR TITLE
Fix reveal order in scratch game

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,8 +155,7 @@
         [revealQueue[i], revealQueue[j]] = [revealQueue[j], revealQueue[i]];
       }
 
-      // Add tie-breaker image (always a girl) as the fifth
-      revealQueue.push('girl.png');
+      // The fifth reveal is always a girl, handled separately
 
       let revealedCount = 0;
 


### PR DESCRIPTION
## Summary
- ensure the first four scratch zones reveal exactly two boys and two girls
- fifth scratch always shows a girl

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_b_687c836e7cb4832f93a63218eb2f7492