### PR TITLE
Fix stray alt text visible before scratching

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,10 @@
       display: block;
     }
 
+    .scratch-zone img:not([src]) {
+      display: none;
+    }
+
     .scratch-zone canvas {
       position: absolute;
       top: 0;


### PR DESCRIPTION
## Summary
- hide placeholder `img` alt text before scratching begins

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687c8471fe58832fb1ae3c1b8f378ca2