### PR TITLE
Add URL parameter for final gender reveal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # Scratch To Reveal
 
 Simple scratchcard demo.
+
+## URL parameters
+
+- `name` – optional name displayed on the ticket.
+- `f` – controls the final reveal. Use `1` for a boy and `2` for a girl. If omitted, a girl is shown.

--- a/index.html
+++ b/index.html
@@ -238,7 +238,9 @@ fitText(el, 32, initialSize); // give a decent min size
         [revealQueue[i], revealQueue[j]] = [revealQueue[j], revealQueue[i]];
       }
 
-      // The fifth reveal is always a girl, handled separately
+      // Determine the final reveal using a URL parameter. "1" means boy, "2" means girl.
+      const params = new URLSearchParams(window.location.search);
+      const finalReveal = params.get('f') === '1' ? 'boy.png' : 'girl.png';
 
       let revealedCount = 0;
 
@@ -251,7 +253,7 @@ fitText(el, 32, initialSize); // give a decent min size
           revealedCount++;
           let src;
           if (revealedCount === 5) {
-            src = 'girl.png';
+            src = finalReveal;
           } else {
             src = revealQueue.pop();
           }


### PR DESCRIPTION
## Summary
- add `f` query parameter to configure the fifth scratch result
- document the new parameter in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6881ab8b5808832fb5f7b4b936d2f332