### PR TITLE
Improve final overlay centering

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,11 +92,11 @@
     }
 
     #reveal-overlay {
-      position: fixed;
+      position: absolute;
       top: 0;
       left: 0;
-      width: 100vw;
-      height: 100vh;
+      width: 100%;
+      height: 100%;
       background-color: rgba(0,0,0,0.8);
       display: flex;
       opacity: 0;
@@ -122,6 +122,7 @@
       color: white;
       font-size: 3rem;
       margin: 1rem;
+      width: 100%;
     }
 
     #reveal-picture {
@@ -139,8 +140,8 @@
     }
 
     @keyframes confetti-fall {
-      0% { transform: translateY(-10vh) rotate(0deg); }
-      100% { transform: translateY(110vh) rotate(360deg); }
+      0% { transform: translateY(var(--start, -10vh)) rotate(0deg); }
+      100% { transform: translateY(var(--end, 110vh)) rotate(360deg); }
     }
   </style>
 </head>
@@ -168,10 +169,10 @@
       <img alt="Reveal" />
       <canvas></canvas>
     </div>
-  </div>
-  <div id="reveal-overlay">
-    <h1 id="reveal-message"></h1>
-    <img id="reveal-picture" alt="" />
+    <div id="reveal-overlay">
+      <h1 id="reveal-message"></h1>
+      <img id="reveal-picture" alt="" />
+    </div>
   </div>
 
   <script>
@@ -189,10 +190,14 @@
         const size = Math.random() * 6 + 4;
         piece.style.width = size + 'px';
         piece.style.height = size + 'px';
-        piece.style.left = Math.random() * 100 + 'vw';
-        piece.style.top = Math.random() * -20 + 'vh';
+        piece.style.left = Math.random() * overlay.clientWidth + 'px';
+        piece.style.top = Math.random() * -overlay.clientHeight * 0.2 + 'px';
         const duration = Math.random() * 3 + 3;
         const delay = Math.random();
+        const startY = -overlay.clientHeight * 0.1 + 'px';
+        const endY = overlay.clientHeight * 1.1 + 'px';
+        piece.style.setProperty('--start', startY);
+        piece.style.setProperty('--end', endY);
         piece.style.animation = `confetti-fall ${duration}s linear ${delay}s forwards`;
         overlay.appendChild(piece);
         setTimeout(() => piece.remove(), (duration + delay) * 1000);


### PR DESCRIPTION
## Summary
- position the final overlay relative to the ticket instead of the full page
- keep overlay text centered regardless of optional image
- adjust confetti animation to use overlay dimensions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6881bfd7a1e0832f8414326a0fc274ed