### PR TITLE
Add custom message and image upload for reveal

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,6 @@ Simple scratchcard demo.
 
 - `name` – optional name displayed on the ticket.
 - `f` – controls the final reveal. Use `1` for a boy and `2` for a girl. If omitted, a girl is shown.
-- `style` – optional font style for the overlay text. Use `plain` to show Penmanship.ttf; anything else defaults to the cursive Kindly font.
+- `style` – optional text style for the overlay. Use `plain` for a printed look or omit for cursive.
+- `msg` – custom message shown after the final reveal.
+- `img` – URL or data URI of an image displayed with the message.

--- a/create/index.html
+++ b/create/index.html
@@ -57,6 +57,19 @@
       border: 1px solid #ccc;
       border-radius: 5px;
     }
+    #drop-area {
+      width: 100%;
+      padding: 1rem;
+      margin-top: 0.25rem;
+      border: 2px dashed #ccc;
+      border-radius: 5px;
+      text-align: center;
+      cursor: pointer;
+    }
+    #drop-area.highlight {
+      border-color: #777;
+    }
+
 
     button {
       margin-top: 1.5rem;
@@ -109,10 +122,19 @@
 
         <label for="style">Font Style</label>
         <select id="style" name="style">
-          <option value="">Cursive (Kindly)</option>
-          <option value="plain">Plain (Penmanship)</option>
+          <option value="">Cursive</option>
+          <option value="plain">Plain</option>
         </select>
 
+        <label for="msg">Reveal Message</label>
+        <input type="text" id="msg" name="msg" />
+        
+        <label for="imgInput">Reveal Image</label>
+        <div id="drop-area">
+          <p id="drop-text">Drop image here or click to choose</p>
+          <img id="drop-preview" alt="" style="display:none; max-width:100%; margin-top:0.5rem;" />
+          <input type="file" id="imgInput" accept="image/*" style="display:none;">
+        </div>
         <button type="submit">Generate Link</button>
       </form>
 
@@ -128,11 +150,43 @@
     const form = document.getElementById('linkForm');
     const result = document.getElementById('result');
     const preview = document.getElementById('live-preview');
+    const dropArea = document.getElementById('drop-area');
+    const imgInput = document.getElementById('imgInput');
+    const dropPreview = document.getElementById('drop-preview');
+    let imgData = '';
+
+    function handleFile(file) {
+      if (!file || !file.type.startsWith('image/')) return;
+      const reader = new FileReader();
+      reader.onload = e => {
+        imgData = e.target.result;
+        dropPreview.src = imgData;
+        dropPreview.style.display = 'block';
+        updatePreview();
+      };
+      reader.readAsDataURL(file);
+    }
+
+    dropArea.addEventListener('click', () => imgInput.click());
+    dropArea.addEventListener('dragover', e => {
+      e.preventDefault();
+      dropArea.classList.add('highlight');
+    });
+    dropArea.addEventListener('dragleave', () => dropArea.classList.remove('highlight'));
+    dropArea.addEventListener('drop', e => {
+      e.preventDefault();
+      dropArea.classList.remove('highlight');
+      if (e.dataTransfer.files.length) handleFile(e.dataTransfer.files[0]);
+    });
+    imgInput.addEventListener('change', () => {
+      if (imgInput.files.length) handleFile(imgInput.files[0]);
+    });
 
     function updatePreview() {
       const name = document.getElementById('name').value.trim();
       const f = document.getElementById('f').value;
       const style = document.getElementById('style').value;
+      const msg = document.getElementById('msg').value.trim();
 
       let url = 'https://scratchtoreveal1.netlify.app/?';
       const params = new URLSearchParams();
@@ -140,6 +194,8 @@
       if (name) params.append('name', name);
       if (f) params.append('f', f);
       if (style) params.append('style', style);
+      if (msg) params.append('msg', msg);
+      if (imgData) params.append('img', imgData);
 
       const finalUrl = url + params.toString();
       preview.src = finalUrl;


### PR DESCRIPTION
## Summary
- allow customizing reveal message and image
- support drag & drop upload (data URI) in link builder
- clarify `style` option and document new parameters

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688275513a4c832fbfc24f8ee4da3e24