### PR TITLE
Fix drag and drop image handling

### DIFF
--- a/create/index.html
+++ b/create/index.html
@@ -176,6 +176,10 @@
     }
 
     dropArea.addEventListener('click', () => imgInput.click());
+    dropArea.addEventListener('dragenter', e => {
+      e.preventDefault();
+      dropArea.classList.add('highlight');
+    });
     dropArea.addEventListener('dragover', e => {
       e.preventDefault();
       dropArea.classList.add('highlight');


### PR DESCRIPTION
## Summary
- add `dragenter` event listener so drag and drop image upload works across browsers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68827c3c7004832f9b66d13642a48550