### PR TITLE
Replace drag-and-drop upload with URL field

### DIFF
--- a/create/index.html
+++ b/create/index.html
@@ -58,18 +58,10 @@
       border-radius: 5px;
     }
 
-    #drop-area {
-      width: 100%;
-      padding: 1rem;
-      margin-top: 0.25rem;
-      border: 2px dashed #ccc;
-      border-radius: 5px;
-      text-align: center;
-      cursor: pointer;
-    }
 
-    #drop-area.highlight {
-      border-color: #777;
+    #img-help {
+      cursor: help;
+      margin-left: 0.25rem;
     }
 
     button {
@@ -106,11 +98,6 @@
       border: none;
     }
 
-    #drop-preview {
-      display: none;
-      max-width: 100%;
-      margin-top: 0.5rem;
-    }
   </style>
 </head>
 <body>
@@ -136,12 +123,8 @@
         <label for="msg">Reveal Message</label>
         <input type="text" id="msg" name="msg" />
 
-        <label for="imgInput">Reveal Image</label>
-        <div id="drop-area">
-          <p id="drop-text">Drop image here or click to choose</p>
-          <img id="drop-preview" alt="Image preview" />
-          <input type="file" id="imgInput" accept="image/*" style="display:none;" />
-        </div>
+        <label for="imgUrl">Reveal Image URL <span id="img-help" title="Upload your image to a service like Imgur and paste the URL here.">?</span></label>
+        <input type="text" id="imgUrl" name="img" />
 
         <button type="submit">Generate Link</button>
       </form>
@@ -158,41 +141,7 @@
     const form = document.getElementById('linkForm');
     const result = document.getElementById('result');
     const preview = document.getElementById('live-preview');
-    const dropArea = document.getElementById('drop-area');
-    const imgInput = document.getElementById('imgInput');
-    const dropPreview = document.getElementById('drop-preview');
-    let imgData = '';
-
-    function handleFile(file) {
-      if (!file || !file.type.startsWith('image/')) return;
-      const reader = new FileReader();
-      reader.onload = e => {
-        imgData = e.target.result;
-        dropPreview.src = imgData;
-        dropPreview.style.display = 'block';
-        updatePreview();
-      };
-      reader.readAsDataURL(file);
-    }
-
-    dropArea.addEventListener('click', () => imgInput.click());
-    dropArea.addEventListener('dragenter', e => {
-      e.preventDefault();
-      dropArea.classList.add('highlight');
-    });
-    dropArea.addEventListener('dragover', e => {
-      e.preventDefault();
-      dropArea.classList.add('highlight');
-    });
-    dropArea.addEventListener('dragleave', () => dropArea.classList.remove('highlight'));
-    dropArea.addEventListener('drop', e => {
-      e.preventDefault();
-      dropArea.classList.remove('highlight');
-      if (e.dataTransfer.files.length) handleFile(e.dataTransfer.files[0]);
-    });
-    imgInput.addEventListener('change', () => {
-      if (imgInput.files.length) handleFile(imgInput.files[0]);
-    });
+    const imgUrlInput = document.getElementById('imgUrl');
 
     async function updatePreview() {
       const name = document.getElementById('name').value.trim();
@@ -205,7 +154,8 @@
       if (f) params.append('f', f);
       if (style) params.append('style', style);
       if (msg) params.append('msg', msg);
-      if (imgData) params.append('img', imgData);
+      const img = imgUrlInput.value.trim();
+      if (img) params.append('img', img);
 
       const fullUrl = `https://scratchtoreveal1.netlify.app/?${params.toString()}`;
       preview.src = fullUrl;


### PR DESCRIPTION
## Summary
- swap drag-and-drop area for a text field to enter an image URL
- show tooltip for uploading to an image host

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68827f23ffac832f9c879e097bcfc1e4