### PR TITLE
Fix check image button

### DIFF
--- a/create/index.html
+++ b/create/index.html
@@ -213,7 +213,7 @@
         updatePreview();
       };
       test.onerror = () => {
-        imgError.textContent = Oops! This link doesn’t lead directly to an image. Right-click the image and choose ‘Copy Image Address’ instead.';
+        imgError.textContent = 'Oops! This link doesn\'t lead directly to an image. Right-click the image and choose \"Copy Image Address\" instead.';
       };
       test.src = url;
     }


### PR DESCRIPTION
## Summary
- fix JavaScript syntax error on Check Image button

## Testing
- `npm test` *(fails: `package.json` missing)*

------
https://chatgpt.com/codex/tasks/task_b_688289019edc832fa07abfe1e67764b2