### PR TITLE
Add independent font style options

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Simple scratchcard demo.
 
 - `name` – optional name displayed on the ticket.
 - `f` – controls the final reveal. Use `1` for a boy and `2` for a girl. If omitted, a girl is shown.
-- `style` – optional text style for the overlay. Use `plain` for a printed look or omit for cursive.
+- `style` – optional text style applied to both the name and final message. Use `plain` for a printed look or omit for cursive. If using the new parameters below, `style` can be omitted.
+- `nameStyle` – optional font style for just the name.
+- `msgStyle` – optional font style for the final reveal message.
 - `msg` – custom message shown after the final reveal.
 - `img` – URL or data URI of an image displayed with the message.

--- a/create/index.html
+++ b/create/index.html
@@ -149,8 +149,14 @@
         <label for="name">Baby’s Name or Last Name</label>
         <input type="text" id="name" name="name" />
 
-        <label for="style">Font Style</label>
-        <select id="style" name="style">
+        <label for="nameStyle">Name Font Style</label>
+        <select id="nameStyle" name="nameStyle">
+          <option value="">Cursive</option>
+          <option value="plain">Plain</option>
+        </select>
+
+        <label for="msgStyle">Message Font Style</label>
+        <select id="msgStyle" name="msgStyle">
           <option value="">Cursive</option>
           <option value="plain">Plain</option>
         </select>
@@ -221,14 +227,16 @@
     async function updatePreview() {
       const name = document.getElementById('name').value.trim();
       const f = document.getElementById('f').value;
-      const style = document.getElementById('style').value;
+      const nameStyle = document.getElementById('nameStyle').value;
+      const msgStyle = document.getElementById('msgStyle').value;
       const msg = document.getElementById('msg').value.trim();
       const img = imgUrlInput.value.trim();
 
       const params = new URLSearchParams();
       if (name) params.append('name', name);
       if (f) params.append('f', f);
-      if (style) params.append('style', style);
+      if (nameStyle) params.append('nameStyle', nameStyle);
+      if (msgStyle) params.append('msgStyle', msgStyle);
       if (msg) params.append('msg', msg);
       if (img) params.append('img', img);
 

--- a/index.html
+++ b/index.html
@@ -204,13 +204,17 @@
     // Disable the standard long-press context menu on mobile devices
     document.addEventListener('contextmenu', event => event.preventDefault());
 
+    function getFont(style) {
+      const usePen = style === 'plain' || style === 'penmanship';
+      return usePen ? "'Penmanship', sans-serif" : "'Kindly', cursive";
+    }
+
     function applyFont() {
       const params = new URLSearchParams(window.location.search);
-      const style = params.get('style');
-      const usePen = style === 'plain' || style === 'penmanship';
-      const font = usePen ? "'Penmanship', sans-serif" : "'Kindly', cursive";
-      document.getElementById('name-container').style.fontFamily = font;
-      document.getElementById('reveal-message').style.fontFamily = font;
+      const nameStyle = params.get('nameStyle') || params.get('style');
+      const msgStyle = params.get('msgStyle') || params.get('style');
+      document.getElementById('name-container').style.fontFamily = getFont(nameStyle);
+      document.getElementById('reveal-message').style.fontFamily = getFont(msgStyle);
     }
 
     function launchConfetti(colors, speed = 1) {


### PR DESCRIPTION
## Summary
- allow fonts for the name and reveal message to be different
- update generator form to pick styles for each
- document new parameters

## Testing
- `npm test` *(fails: could not read package.json)*
- `npm run lint` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68828ab70d80832fb50ecaca09a4abb7