### PR TITLE
Default name to Baby

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Simple scratchcard demo.
 
 ## URL parameters
 
-- `name` – optional name displayed on the ticket.
+- `name` – optional name displayed on the ticket. Defaults to "Baby" if omitted.
 - `f` – controls the final reveal. Use `1` for a boy and `2` for a girl. If omitted, a girl is shown.
 - `style` – optional text style applied to both the name and final message. Use `plain` for a printed look or omit for cursive. If using the new parameters below, `style` can be omitted.
 - `nameStyle` – optional font style for just the name.

--- a/index.html
+++ b/index.html
@@ -287,7 +287,7 @@
     function initName() {
       const el = document.getElementById('name-container');
       const params = new URLSearchParams(window.location.search);
-      const name = params.get('name') || '';
+      const name = params.get('name') || 'Baby';
       el.textContent = name;
       const fit = () => {
         const container = document.getElementById('container');


### PR DESCRIPTION
## Summary
- default to `Baby` when `name` URL parameter is missing
- document the default behavior in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688296b8d648832f8fe153274eeda914