### PR TITLE
Enable preview overlay for live generator view

### DIFF
--- a/create/index.html
+++ b/create/index.html
@@ -281,7 +281,9 @@
     }
 
     function updatePreview() {
-      preview.src = buildUrl();
+      const url = new URL(buildUrl());
+      url.searchParams.set('preview', '1');
+      preview.src = url.toString();
     }
 
     async function generateLink() {

--- a/index.html
+++ b/index.html
@@ -378,6 +378,18 @@ fitText(el, 32, initialSize * 1.3);
     document.addEventListener('DOMContentLoaded', () => {
       applyFont();
       initName();
+
+      const params = new URLSearchParams(window.location.search);
+      const finalReveal = params.get('f') === '1' ? 'boy.png' : 'girl.png';
+      const customMessage = params.get('msg');
+      const customImg = params.get('img');
+      const preview = params.get('preview') === '1';
+
+      if (preview) {
+        showFinalOverlay(finalReveal.includes('boy'), customMessage, customImg);
+        return;
+      }
+
       const zones = document.querySelectorAll('.scratch-zone');
 
       const revealQueue = ['girl.png', 'girl.png', 'boy.png', 'boy.png'];
@@ -385,11 +397,6 @@ fitText(el, 32, initialSize * 1.3);
         const j = Math.floor(Math.random() * (i + 1));
         [revealQueue[i], revealQueue[j]] = [revealQueue[j], revealQueue[i]];
       }
-
-      const params = new URLSearchParams(window.location.search);
-      const finalReveal = params.get('f') === '1' ? 'boy.png' : 'girl.png';
-      const customMessage = params.get('msg');
-      const customImg = params.get('img');
 
       let revealedCount = 0;
 


### PR DESCRIPTION
## Summary
- add preview parameter support in main page
- automatically show final overlay when `preview=1`
- ensure the creator live preview adds `preview=1`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688298ee13b0832f8d727878d460bb6e