### PR TITLE
Add mobile preview button

### DIFF
--- a/create/index.html
+++ b/create/index.html
@@ -106,6 +106,28 @@
       font-size: 1rem;
     }
 
+    .button-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+
+    .button-row button {
+      flex: 1;
+    }
+
+    #generate {
+      order: 1;
+    }
+
+    #previewBtn {
+      order: 2;
+    }
+
+    #copy {
+      order: 3;
+    }
+
     button:disabled {
       opacity: 0.6;
       cursor: default;
@@ -163,6 +185,9 @@
       }
       iframe {
         height: 600px;
+      }
+      #previewBtn {
+        order: 0;
       }
     }
 
@@ -227,8 +252,11 @@
         <div id="imgError" aria-live="polite"></div>
         <small>Optional – leave blank if you don't want a custom image.</small>
       </form>
-      <button type="button" id="generate">Generate URL</button>
-      <button type="button" id="copy" style="display:none;">Copy to Clipboard</button>
+      <div class="button-row">
+        <button type="button" id="generate">Generate URL</button>
+        <button type="button" id="previewBtn">Preview</button>
+        <button type="button" id="copy" style="display:none;">Copy to Clipboard</button>
+      </div>
       <div id="result"></div>
     </div>
 
@@ -244,6 +272,7 @@
     const imgUrlInput = document.getElementById('imgUrl');
     const imgError = document.getElementById('imgError');
     const generateBtn = document.getElementById('generate');
+    const previewBtn = document.getElementById('previewBtn');
     const copyBtn = document.getElementById('copy');
     let validateTimeout;
 
@@ -326,6 +355,7 @@
     form.addEventListener('change', updatePreview);
     imgUrlInput.addEventListener('input', scheduleImageValidation);
     imgUrlInput.addEventListener('change', validateImage);
+    previewBtn.addEventListener('click', updatePreview);
     generateBtn.addEventListener('click', generateLink);
     copyBtn.addEventListener('click', async () => {
       const text = copyBtn.dataset.clipboard;


### PR DESCRIPTION
## Summary
- add preview button with responsive ordering
- update styling and script to support preview button

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_68829990fb7c832f97b1a2f15f5b243b