### PR TITLE
Enable manual preview reveal

### DIFF
--- a/create/index.html
+++ b/create/index.html
@@ -281,7 +281,9 @@
     }
 
     function updatePreview() {
-      preview.src = buildUrl();
+      const url = new URL(buildUrl());
+      url.searchParams.set('preview', '1');
+      preview.src = url.toString();
     }
 
     async function generateLink() {

--- a/index.html
+++ b/index.html
@@ -145,6 +145,20 @@
       width: 100%;
     }
 
+    #preview-btn {
+      position: absolute;
+      top: 1rem;
+      right: 1rem;
+      background: rgba(0,0,0,0.6);
+      color: white;
+      border: none;
+      border-radius: 5px;
+      padding: 0.4rem 0.6rem;
+      font-size: 0.9rem;
+      z-index: 1001;
+      cursor: pointer;
+    }
+
     #reveal-picture {
       max-width: 80%;
       max-height: 50%;
@@ -378,6 +392,23 @@ fitText(el, 32, initialSize * 1.3);
     document.addEventListener('DOMContentLoaded', () => {
       applyFont();
       initName();
+
+      const params = new URLSearchParams(window.location.search);
+      const finalReveal = params.get('f') === '1' ? 'boy.png' : 'girl.png';
+      const customMessage = params.get('msg');
+      const customImg = params.get('img');
+      const preview = params.get('preview') === '1';
+
+      if (preview) {
+        const btn = document.createElement('button');
+        btn.id = 'preview-btn';
+        btn.textContent = 'Reveal Message';
+        btn.addEventListener('click', () => {
+          showFinalOverlay(finalReveal.includes('boy'), customMessage, customImg);
+        });
+        document.getElementById('container').appendChild(btn);
+      }
+
       const zones = document.querySelectorAll('.scratch-zone');
 
       const revealQueue = ['girl.png', 'girl.png', 'boy.png', 'boy.png'];
@@ -385,11 +416,6 @@ fitText(el, 32, initialSize * 1.3);
         const j = Math.floor(Math.random() * (i + 1));
         [revealQueue[i], revealQueue[j]] = [revealQueue[j], revealQueue[i]];
       }
-
-      const params = new URLSearchParams(window.location.search);
-      const finalReveal = params.get('f') === '1' ? 'boy.png' : 'girl.png';
-      const customMessage = params.get('msg');
-      const customImg = params.get('img');
 
       let revealedCount = 0;
 


### PR DESCRIPTION
## Summary
- add 'Reveal Message' button for preview mode
- keep scratch page visible on preview

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688298ee13b0832f8d727878d460bb6e