### PR TITLE
Add preview support and reposition preview button

### DIFF
--- a/create/index.html
+++ b/create/index.html
@@ -307,7 +307,7 @@
       validateTimeout = setTimeout(validateImage, 500);
     }
 
-    function buildUrl() {
+    function buildUrl(includePreview = false) {
       const name = document.getElementById('name').value.trim();
       const f = document.getElementById('f').value;
       const nameStyle = document.getElementById('nameStyle').value;
@@ -322,14 +322,13 @@
       if (msgStyle) params.append('msgStyle', msgStyle);
       if (msg) params.append('msg', msg);
       if (img) params.append('img', img);
+      if (includePreview) params.append('preview', '1');
 
       return `https://scratchtoreveal1.netlify.app/?${params.toString()}`;
     }
 
     function updatePreview() {
-      const url = new URL(buildUrl());
-      url.searchParams.set('preview', '1');
-      preview.src = url.toString();
+      preview.src = buildUrl(true);
     }
 
     async function generateLink() {

--- a/index.html
+++ b/index.html
@@ -147,8 +147,9 @@
 
     #preview-btn {
       position: absolute;
-      top: 1rem;
-      right: 1rem;
+      bottom: 1rem;
+      left: 50%;
+      transform: translateX(-50%);
       background: rgba(0,0,0,0.6);
       color: white;
       border: none;


### PR DESCRIPTION
## Summary
- allow `buildUrl()` to include preview parameters
- show preview URL directly via `buildUrl(true)` in create page
- move preview button to bottom centre of reveal page

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_b_68829e820f34832f9ec1ca9a4d46ac8b