### PR TITLE
Improve mobile centering for form

### DIFF
--- a/create/index.html
+++ b/create/index.html
@@ -30,6 +30,7 @@
       gap: 2rem;
       max-width: 1200px;
       width: 100%;
+      margin: 0 auto; /* keep centered within the page */
     }
     .form-section {
       border: 1px solid #f9d6da;
@@ -191,6 +192,11 @@
       }
       .form-box {
         width: 100%;
+        margin: 0 auto; /* center form on narrow screens */
+      }
+      .form-section,
+      label {
+        text-align: center; /* center labels and sections */
       }
       .preview-box {
         width: 100%;


### PR DESCRIPTION
## Summary
- center the link creation form on mobile
- center labels and questions when screen width is narrow

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6882acce38ec832fb0c45054888459be