### PR TITLE
Update reveal overlay color for boy

### DIFF
--- a/index.html
+++ b/index.html
@@ -259,7 +259,7 @@
 
     function showFinalOverlay(isBoy, message, img) {
       const overlay = document.getElementById('reveal-overlay');
-      overlay.style.backgroundColor = isBoy ? '#87cefa' : '#ffb6c1';
+      overlay.style.backgroundColor = isBoy ? '#add0e9' : '#ffb6c1';
       const msgEl = document.getElementById('reveal-message');
       msgEl.textContent = message || (isBoy ? "We're having a boy!" : "We're having a girl!");
       const imgEl = document.getElementById('reveal-picture');


### PR DESCRIPTION
## Summary
- tweak color of overlay shown when revealing a boy to `#add0e9`

## Testing
- `grep -n '#add0e9' -n index.html`


------
https://chatgpt.com/codex/tasks/task_b_6883b3ae57dc832fbe2aa7330e5d3665