### PR TITLE
Update domain to custom URL

### DIFF
--- a/create/index.html
+++ b/create/index.html
@@ -285,7 +285,7 @@
     </div>
 
     <div class="preview-box">
-      <iframe id="live-preview" src="https://scratchtoreveal1.netlify.app/" title="Live Preview"></iframe>
+      <iframe id="live-preview" src="https://scratch.joyjotstudio.store/" title="Live Preview"></iframe>
     </div>
   </div>
 
@@ -347,7 +347,7 @@
       if (img) params.append('img', img);
       if (includePreview) params.append('preview', '1');
 
-      return `https://scratchtoreveal1.netlify.app/?${params.toString()}`;
+      return `https://scratch.joyjotstudio.store/?${params.toString()}`;
     }
 
     function updatePreview() {

--- a/index.html
+++ b/index.html
@@ -8,12 +8,12 @@
   <meta property="og:type" content="website" />
   <meta property="og:title" content="Gender Reveal Scratcher" />
   <meta property="og:description" content="Scratch to see what Baby will be!" />
-  <meta property="og:image" content="https://scratchtoreveal1.netlify.app/og-preview.png" />
+  <meta property="og:image" content="https://scratch.joyjotstudio.store/og-preview.png" />
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Gender Reveal Scratcher" />
   <meta name="twitter:description" content="Scratch to see what Baby will be!" />
-  <meta name="twitter:image" content="https://scratchtoreveal1.netlify.app/og-preview.png" />
+  <meta name="twitter:image" content="https://scratch.joyjotstudio.store/og-preview.png" />
   <link rel="preload" href="Kindly.otf" as="font" type="font/otf" crossorigin>
   <link rel="preload" href="Penmanship.ttf" as="font" type="font/ttf" crossorigin>
   <link rel="preload" href="background.png" as="image" fetchpriority="high">


### PR DESCRIPTION
## Summary
- update preview frame and generated link to use `scratch.joyjotstudio.store`
- switch Open Graph and Twitter preview images to the same custom domain

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6883ddbc10e0832f8473ef49bf769a98