### PR TITLE
Fix preview box height

### DIFF
--- a/create/form.html
+++ b/create/form.html
@@ -32,6 +32,7 @@
       max-width: 1200px;
       width: 100%;
       margin: 0 auto; /* keep centered within the page */
+      align-items: flex-start; /* prevent preview box stretching */
     }
     .form-section {
       border: 1px solid #ccc;


### PR DESCRIPTION
## Summary
- prevent the preview pane from stretching taller than the iframe

## Testing
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_b_68844d4257bc832f8b1dfad6521d61c3