### PR TITLE
feat: obfuscate message parameters

### DIFF
--- a/create/form.html
+++ b/create/form.html
@@ -352,7 +352,8 @@
       if (img) params.append('img', img);
       if (includePreview) params.append('preview', '1');
 
-      return `https://scratch.joyjotstudio.store/?${params.toString()}`;
+      const encoded = encodeURIComponent(btoa(params.toString()));
+      return `https://scratch.joyjotstudio.store/?d=${encoded}`;
     }
 
     function updatePreview() {

--- a/index.html
+++ b/index.html
@@ -23,7 +23,18 @@
   <link rel="preload" href="boy.png" as="image">
   <script>
     (function(){
-      const params = new URLSearchParams(location.search);
+      const searchParams = new URLSearchParams(location.search);
+      let params;
+      if (searchParams.has('d')) {
+        try {
+          const decoded = atob(decodeURIComponent(searchParams.get('d')));
+          params = new URLSearchParams(decoded);
+        } catch (e) {
+          params = searchParams;
+        }
+      } else {
+        params = searchParams;
+      }
       window.initialParams = params;
       window.initialName = params.get('name') || 'Baby';
       function fontVal(style){
@@ -403,7 +414,7 @@ fitText(el, 32, initialSize * 1.3);
     document.addEventListener('DOMContentLoaded', () => {
       initName();
 
-      const params = new URLSearchParams(window.location.search);
+      const params = window.initialParams || new URLSearchParams(window.location.search);
       const finalReveal = params.get('f') === '1' ? 'boy.png' : 'girl.png';
       const customMessage = params.get('msg');
       const customImg = params.get('img');


### PR DESCRIPTION
## Summary
- Base64-encode form query parameters into single `d` param
- Decode `d` param on main page and use for preview logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68918132c3e8832fa2059249b589bee9