### PR TITLE
Use TextDecoder for decoding initial params

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,10 @@
       let params;
       if (searchParams.has('d')) {
         try {
-          const decoded = atob(decodeURIComponent(searchParams.get('d')));
+          const b64 = decodeURIComponent(searchParams.get('d'));
+          const decoded = new TextDecoder().decode(
+            Uint8Array.from(atob(b64), c => c.charCodeAt(0))
+          );
           params = new URLSearchParams(decoded);
         } catch (e) {
           params = searchParams;


### PR DESCRIPTION
## Summary
- decode `d` query parameter with TextDecoder and Uint8Array

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b8c275fcec832fb141886cf14e3855