### PR TITLE
Hide name container until ready

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,6 +99,8 @@
       overflow: hidden;
       transform: translateY(-50%);
       pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.3s ease;
     }
 
     #ticket {
@@ -343,7 +345,10 @@ fitText(el, 32, initialSize * 1.3);
       };
       const ticket = document.getElementById('ticket');
       const ticketReady = ticket.complete ? Promise.resolve() : new Promise(r => ticket.addEventListener('load', r, {once: true}));
-      Promise.all([document.fonts.ready, ticketReady]).then(fit);
+      Promise.all([document.fonts.ready, ticketReady]).then(() => {
+        fit();
+        el.style.opacity = '1';
+      });
       window.addEventListener('resize', fit);
     }
 


### PR DESCRIPTION
## Summary
- Initially hide the name container so it fades in after assets load
- Reveal the name container once fonts and ticket image are ready and then fit text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b8c58d04dc832fa26fd081e1fafd41